### PR TITLE
[WIP] Switch CI to GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,14 @@
+name: Build LaTeX document
+on: [push]
+
+jobs:
+  build_latex:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Install xmllint
+        run: sudo apt-get install -y texlive-full
+
+      - name: Compile LaTeX document
+        uses: xu-cheng/latex-action@v2
+        with:
+          root_file: Thesis.tex


### PR DESCRIPTION
I have used [Github Action for LaTeX](https://github.com/marketplace/actions/github-action-for-latex) to start playing with GitHub Actions (GHA). It looks like Ubuntu 16 is not available on GitHub, though.